### PR TITLE
Introduce @JsonExclude decorator

### DIFF
--- a/spec/Entity.spec.ts
+++ b/spec/Entity.spec.ts
@@ -2,6 +2,7 @@ import {Entity} from '../src/Entity';
 import {Type} from '../src/support/Type';
 import { EntityBuilder } from "../src/EntityBuilder";
 import {Default} from "../src/support/Default";
+import {JsonExclude} from '../src/support/JsonExclude';
 
 class User extends Entity {
     public name: string = null;
@@ -54,6 +55,11 @@ class UserWithAnnotatedObject extends User {
 class UserWithDefaultValue extends User {
     @Default(() => 'hi')
     public value: string = null;
+}
+
+class UserWithExcludedOutput extends User {
+    @JsonExclude()
+    public value: string = 'test';
 }
 
 describe('Entity', () => {
@@ -372,4 +378,13 @@ describe('Entity', () => {
 
         expect(user.value).toEqual('hi');
     });
+
+    it('excludes @JsonExclude annotated keys from the output object', () => {
+        const user = new UserWithExcludedOutput();
+        user.name = 'Batman';
+        user.email = 'noreply@batman.example.com';
+
+        const output = user.toJson();
+        expect(output.value).toBeUndefined();
+    })
 });

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -115,6 +115,11 @@ export class Entity {
                 continue;
             }
 
+            // exclude any properties with `@JsonExclude()`
+            if (defaultMetadataStorage.isPropertyExcluded(this.constructor, key)) {
+                continue;
+            }
+
             let outputKey = toSnake ? StringHelper.toSnake(key) : key;
 
             const value: any = this[key];

--- a/src/support/JsonExclude.ts
+++ b/src/support/JsonExclude.ts
@@ -1,0 +1,9 @@
+import { defaultMetadataStorage } from './storage';
+import {JsonExcludeMetadata} from './metadata/JsonExcludeMetadata';
+
+export function JsonExclude() {
+    return function (target: any, key: string) {
+        const metadata = new JsonExcludeMetadata(target.constructor, key);
+        defaultMetadataStorage.addExcludeProperty(metadata);
+    };
+}

--- a/src/support/metadata/JsonExcludeMetadata.ts
+++ b/src/support/metadata/JsonExcludeMetadata.ts
@@ -1,0 +1,3 @@
+export class JsonExcludeMetadata {
+    constructor(public target: Function, public propertyName: string) {}
+}

--- a/src/support/metadata/MetadataStorage.ts
+++ b/src/support/metadata/MetadataStorage.ts
@@ -1,4 +1,5 @@
 import { TypeMetadata } from './TypeMetadata';
+import {JsonExcludeMetadata} from './JsonExcludeMetadata';
 
 export class DefaultValueCallbackMetadata {
     constructor(public target: Function,
@@ -19,6 +20,7 @@ export class MetadataStorage {
      */
     private typeMetadatas: TypeMetadata[] = [];
     private defaultCallbacks: DefaultValueCallbackMetadata[] = [];
+    private excludedProperties: JsonExcludeMetadata[] = [];
 
     /**
      * Append type metadata.
@@ -31,6 +33,10 @@ export class MetadataStorage {
 
     addDefaultCallback(callbackMetadata: DefaultValueCallbackMetadata) {
         this.defaultCallbacks.push(callbackMetadata);
+    }
+
+    addExcludeProperty(excludeMeta: JsonExcludeMetadata) {
+        this.excludedProperties.push(excludeMeta);
     }
 
     /**
@@ -55,5 +61,10 @@ export class MetadataStorage {
     findCallback(target: any, propertyName: string): DefaultValueCallbackMetadata|undefined {
         return this.defaultCallbacks.find(cbmeta => cbmeta.target === target && cbmeta.propertyName === propertyName) ||
             this.defaultCallbacks.find(cbmeta => target.prototype instanceof cbmeta.target && cbmeta.propertyName === propertyName);
+    }
+
+    isPropertyExcluded(target: any, propertyName: string): boolean {
+        return this.excludedProperties.some(propertyMeta => propertyMeta.target === target && propertyMeta.propertyName === propertyName) ||
+            this.excludedProperties.some(propertyMeta => target.prototype instanceof propertyMeta.target && propertyMeta.propertyName === propertyName);
     }
 }


### PR DESCRIPTION
This allows users to use @JsonExclude on a property
to exclude it from the output object of toJson.