### PR TITLE
Introducing typed import and export objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules
 .idea
 npm-debug.log
 dist
-package-lock.json
 yarn.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,317 @@
+{
+  "name": "@decahedron/entity",
+  "version": "3.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@decahedron/entity",
+      "version": "3.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jasmine": "^2.5.52",
+        "@types/node": "^11.11.4",
+        "jasmine": "^2.6.0",
+        "reflect-metadata": "^0.1.13",
+        "typescript": "^4.1"
+      }
+    },
+    "node_modules/@types/jasmine": {
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.18.tgz",
+      "integrity": "sha512-CYOO2DsfoFnmYQ+tZyXsExePUomwvUhpSLEsM7kAJ5BSYNlom+5m3qZkxYrg2CoSfJ3tMv5NH02cB0y7GfjvaA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "11.15.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
+      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/jasmine": {
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.99.0.tgz",
+      "integrity": "sha1-jKctEC5jm4Z8ZImFbg4YqceqQrc=",
+      "dev": true,
+      "dependencies": {
+        "exit": "^0.1.2",
+        "glob": "^7.0.6",
+        "jasmine-core": "~2.99.0"
+      },
+      "bin": {
+        "jasmine": "bin/jasmine.js"
+      }
+    },
+    "node_modules/jasmine-core": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
+      "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@types/jasmine": {
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.18.tgz",
+      "integrity": "sha512-CYOO2DsfoFnmYQ+tZyXsExePUomwvUhpSLEsM7kAJ5BSYNlom+5m3qZkxYrg2CoSfJ3tMv5NH02cB0y7GfjvaA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "11.15.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
+      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jasmine": {
+      "version": "2.99.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.99.0.tgz",
+      "integrity": "sha1-jKctEC5jm4Z8ZImFbg4YqceqQrc=",
+      "dev": true,
+      "requires": {
+        "exit": "^0.1.2",
+        "glob": "^7.0.6",
+        "jasmine-core": "~2.99.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
+      "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^11.11.4",
     "jasmine": "^2.6.0",
     "reflect-metadata": "^0.1.13",
-    "typescript": "^2.0"
+    "typescript": "^4.1"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decahedron/entity",
-  "version": "2.10.0",
+  "version": "3.0.0",
   "description": "A library to encode and decode JSON into entity classes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/spec/Entity.spec.ts
+++ b/spec/Entity.spec.ts
@@ -3,6 +3,7 @@ import {Type} from '../src/support/Type';
 import { EntityBuilder } from "../src/EntityBuilder";
 import {Default} from "../src/support/Default";
 import {JsonExclude} from '../src/support/JsonExclude';
+import { AliasFor } from '../src/support/AliasFor';
 
 class User extends Entity {
     public name: string = null;
@@ -43,7 +44,8 @@ class UserWithAnnotatedPosts extends User {
 }
 
 class UserWithAliasedPrimitive extends User {
-    @Type(String, 'second_name')
+    @AliasFor('middleName')
+    public secondName: string;
     public middleName: string;
 }
 

--- a/spec/Type.spec.ts
+++ b/spec/Type.spec.ts
@@ -1,5 +1,6 @@
 import {Type} from '../src/support/Type';
 import {defaultMetadataStorage} from '../src/support/storage';
+import { Entity } from '../src/Entity';
 
 class Decorated {
 
@@ -10,7 +11,7 @@ describe('Decorators - Type', () => {
         it('Stores the target type, attribute name and infers the source attribute name', () => {
             let decorator = Type(Decorated);
             let fn = (): null => null;
-            decorator(fn, 'attribute');
+            decorator(fn as unknown as Entity, 'attribute');
 
             let storedMetadata = defaultMetadataStorage.findTypeMetadata(fn.constructor, 'attribute');
             expect(storedMetadata).not.toBeUndefined();
@@ -22,7 +23,7 @@ describe('Decorators - Type', () => {
         it('Infers that the source name should be snake_case', () => {
             let decorator = Type(Decorated);
             let fn = (): null => null;
-            decorator(fn, 'camelAttribute');
+            decorator(fn as unknown as Entity, 'camelAttribute');
 
             let storedMetadata = defaultMetadataStorage.findTypeMetadata(fn.constructor, 'camel_attribute');
             expect(storedMetadata).not.toBeUndefined();
@@ -35,7 +36,7 @@ describe('Decorators - Type', () => {
     it('Allows manually overriding the source attribute name', () => {
         let decorator = Type(Decorated, 'camelAttribute');
         let fn = (): null => null;
-        decorator(fn, 'camelAttribute');
+        decorator(fn as unknown as Entity, 'camelAttribute');
 
         let storedMetadata = defaultMetadataStorage.findTypeMetadata(fn.constructor, 'camelAttribute');
         expect(storedMetadata).not.toBeUndefined();

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -100,13 +100,7 @@ export class Entity {
             return true;
         }
 
-        const metadata = defaultMetadataStorage.findTypeMetadata(this.constructor, key);
-
-        if (metadata) {
-            return true;
-        }
-
-        return false;
+        return !!defaultMetadataStorage.findTypeMetadata(this.constructor, key);
     }
 
     getProp(key: string) {

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -5,7 +5,7 @@ import { StringHelper } from './support/StringHelper';
 
 type CamelToSnake<T extends string> = string extends T ? string :
     T extends `${infer C0}${infer R}` ?
-        `${C0 extends Uppercase<C0> ? "_" : ""}${Lowercase<C0>}${CamelToSnake<R>}` :
+        `${C0 extends "_" ? "" : C0 extends Uppercase<C0> ? "_" : ""}${Lowercase<C0>}${CamelToSnake<R>}` :
         "";
 
 type CamelKeysToSnake<T> = T extends readonly any[] ?

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -47,7 +47,8 @@ export class Entity {
 
             let value = data[key] as any;
 
-            const metadata: TypeMetadata = defaultMetadataStorage.findTypeMetadata(entity.constructor, key);
+            const metadata: TypeMetadata = defaultMetadataStorage.findTypeMetadata(entity.constructor, key)
+                || defaultMetadataStorage.findTypeMetadata(entity.constructor, StringHelper.toCamel(key));
 
             // We shouldn't copy objects to our entity, as the entity
             // should be responsible for constructing these itself.
@@ -96,18 +97,10 @@ export class Entity {
     }
 
     private getProp(key: string) {
-        if (!this.hasOwnProperty(key)) {
-            return;
-        }
-
         return (this as any)[key];
     }
 
     private setProp(key: string, value: any) {
-        if (!this.hasOwnProperty(key)) {
-            return;
-        }
-
         (this as any)[key] = value;
     }
 

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -26,7 +26,7 @@ type EntityPropsOnly<T> = {
 
 export class Entity {
 
-    private static async jsonParseAsync<T extends {[key: string]: any}>(sourceObject: T, jsonObject: any): Promise<T> {
+    private static async jsonParseAsync<T extends Entity>(sourceObject: T, jsonObject: Partial<CamelKeysToSnake<EntityPropsOnly<T>>>): Promise<T> {
         const obj = Entity.jsonParse<T>(sourceObject, jsonObject, true);
         for (const key in obj) {
             if (obj.hasOwnProperty(key)) {
@@ -39,74 +39,90 @@ export class Entity {
     /*
      * Parse a generic object into an entity object.
      */
-    private static jsonParse<T extends {[key: string]: any}>(sourceObject: T, jsonObject: any, async = false): T {
-        for (let key in jsonObject) {
-            if (jsonObject.hasOwnProperty(key)) {
-                const metadata: TypeMetadata = defaultMetadataStorage.findTypeMetadata(sourceObject.constructor, key);
-                const value: any = jsonObject[key];
+    private static jsonParse<T extends Entity>(entity: T, data: Partial<CamelKeysToSnake<EntityPropsOnly<T>>>, async = false): T {
+        for (let key in data) {
+            if (!data.hasOwnProperty(key)) {
+                continue;
+            }
 
-                // We shouldn't copy objects to our entity, as the entity
-                // should be responsible for constructing these itself.
-                if (value !== null && typeof value === 'object' && !(value instanceof Array)) {
-                    if (metadata) {
-                        sourceObject[metadata.propertyName] = async
-                            ? EntityBuilder.buildOneAsync(metadata.type, value)
-                            : EntityBuilder.buildOne(metadata.type, value);
-                    }
+            let value = data[key] as any;
 
-                    continue;
-                }
+            const metadata: TypeMetadata = defaultMetadataStorage.findTypeMetadata(entity.constructor, key);
 
-                // if we have an array, we check if it contains objects,
-                // in which case the entity itself should be assumed
-                // responsible to construct the array of entities.
-                if (value instanceof Array && value.length > 0 && typeof value[0] === 'object') {
-                    if (metadata) {
-                        sourceObject[metadata.propertyName] = async
-                            ? EntityBuilder.buildManyAsync(metadata.type, value)
-                            : EntityBuilder.buildMany(metadata.type, value);
-                    }
-
-                    continue;
-                }
-
-                // Since all other scenarios have been exhausted, we're dealing with a primitive of some form.
-                // This can be an empty array of objects too, but since it's empty, there's no need for us
-                // to build an entity. As such, we can just assign it. The same goes for all primitives.
+            // We shouldn't copy objects to our entity, as the entity
+            // should be responsible for constructing these itself.
+            if (value !== null && typeof value === 'object' && !(value instanceof Array)) {
                 if (metadata) {
-                    sourceObject[metadata.propertyName] = value;
-
-                    continue;
+                    entity.setProp(
+                        metadata.propertyName,
+                        async
+                            ? EntityBuilder.buildOneAsync(metadata.type, value)
+                            : EntityBuilder.buildOne(metadata.type, value)
+                    );
                 }
-
-                key = EntityBuilder.enableCamelConversion ? StringHelper.toCamel(key) : key;
-
-                if (sourceObject.hasOwnProperty(key)) {
-                    sourceObject[key] = value;
+                continue;
+            }
+            // if we have an array, we check if it contains objects,
+            // in which case the entity itself should be assumed
+            // responsible to construct the array of entities.
+            if (value instanceof Array && value.length > 0 && typeof value[0] === 'object') {
+                if (metadata) {
+                    entity.setProp(
+                        metadata.propertyName,
+                        async
+                            ? EntityBuilder.buildManyAsync(metadata.type, value)
+                            : EntityBuilder.buildMany(metadata.type, value)
+                    );
                 }
-
-                const defaultValueCallback = defaultMetadataStorage.findCallback(sourceObject.constructor, key);
-                if (defaultValueCallback && defaultValueCallback.condition(sourceObject[key])) {
-                    sourceObject[key] = defaultValueCallback.callback();
-                }
+                continue;
+            }
+            // Since all other scenarios have been exhausted, we're dealing with a primitive of some form.
+            // This can be an empty array of objects too, but since it's empty, there's no need for us
+            // to build an entity. As such, we can just assign it. The same goes for all primitives.
+            if (metadata) {
+                entity.setProp(metadata.propertyName, value);
+                continue;
+            }
+            const newKey = EntityBuilder.enableCamelConversion ? StringHelper.toCamel(key) : key;
+            if (entity.hasOwnProperty(newKey)) {
+                entity.setProp(newKey, value);
+            }
+            const defaultValueCallback = defaultMetadataStorage.findCallback(entity.constructor, newKey);
+            if (defaultValueCallback && defaultValueCallback.condition(entity.getProp(newKey))) {
+                entity.setProp(newKey, defaultValueCallback.callback());
             }
         }
+        return entity as T;
+    }
 
-        return sourceObject;
+    private getProp(key: string) {
+        if (!this.hasOwnProperty(key)) {
+            return;
+        }
+
+        return (this as any)[key];
+    }
+
+    private setProp(key: string, value: any) {
+        if (!this.hasOwnProperty(key)) {
+            return;
+        }
+
+        (this as any)[key] = value;
     }
 
     /*
      * Convert JSON data to an Entity instance.
      */
-    fromJson(jsonData: Partial<CamelKeysToSnake<EntityPropsOnly<this>>>): void {
-        Entity.jsonParse(this, jsonData);
+    fromJson<T extends Entity>(this: T, jsonData: Partial<CamelKeysToSnake<EntityPropsOnly<T>>>): void {
+        Entity.jsonParse<T>(this, jsonData);
     }
 
     /*
      * Convert JSON data to an Entity instance that has async types.
      */
-    async fromJsonAsync(jsonData: any): Promise<void> {
-        await Entity.jsonParseAsync(this, jsonData);
+    async fromJsonAsync<T extends Entity>(this: T, jsonData: Partial<CamelKeysToSnake<EntityPropsOnly<T>>>): Promise<void> {
+        await Entity.jsonParseAsync<T>(this, jsonData);
     }
 
     toJson(toSnake?: true, asString?: false): CamelKeysToSnake<EntityPropsOnly<this>>;

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -47,8 +47,7 @@ export class Entity {
 
             let value = data[key] as any;
 
-            const metadata: TypeMetadata = defaultMetadataStorage.findTypeMetadata(entity.constructor, key)
-                || defaultMetadataStorage.findTypeMetadata(entity.constructor, StringHelper.toCamel(key));
+            const metadata: TypeMetadata = defaultMetadataStorage.findTypeMetadata(entity.constructor, key);
 
             // We shouldn't copy objects to our entity, as the entity
             // should be responsible for constructing these itself.
@@ -85,7 +84,7 @@ export class Entity {
                 continue;
             }
             const newKey = EntityBuilder.enableCamelConversion ? StringHelper.toCamel(key) : key;
-            if (entity.hasOwnProperty(newKey)) {
+            if (newKey in entity) {
                 entity.setProp(newKey, value);
             }
             const defaultValueCallback = defaultMetadataStorage.findCallback(entity.constructor, newKey);
@@ -96,11 +95,33 @@ export class Entity {
         return entity as T;
     }
 
-    private getProp(key: string) {
+    hasProp(key: string): boolean {
+        if (key in this) {
+            return true;
+        }
+
+        const metadata = defaultMetadataStorage.findTypeMetadata(this.constructor, key);
+
+        if (metadata) {
+            return true;
+        }
+
+        return false;
+    }
+
+    getProp(key: string) {
+        if (!this.hasProp(key)) {
+            return;
+        }
+
         return (this as any)[key];
     }
 
-    private setProp(key: string, value: any) {
+    setProp(key: string, value: any) {
+        if (!this.hasProp(key)) {
+            return;
+        }
+
         (this as any)[key] = value;
     }
 

--- a/src/support/AliasFor.ts
+++ b/src/support/AliasFor.ts
@@ -1,16 +1,20 @@
 import { Entity } from '../Entity';
-import { EntityBuilder } from '../EntityBuilder';
-import { StringHelper } from './StringHelper';
-import { TypeMetadata } from './metadata/TypeMetadata';
-import { defaultMetadataStorage } from './storage';
 
 export function AliasFor(key?: string) {
     return function (target: Entity, jsonKey: string) {
-        jsonKey = jsonKey ? jsonKey : (
-            EntityBuilder.enableCamelConversion ? StringHelper.toSnake(key) : key
-        );
+        Object.defineProperty(target, key, {
+            enumerable: true,
+            writable: true,
+        });
 
-        const metadata = new TypeMetadata(target.constructor, key, jsonKey, (value: any) => value);
-        defaultMetadataStorage.addTypeMetadata(metadata);
+        Object.defineProperty(target, jsonKey, {
+            get() {
+                return target.getProp(key);
+            },
+            set(value: any) {
+                target.setProp(key, value);
+            },
+            enumerable: true,
+        });
     };
 }

--- a/src/support/AliasFor.ts
+++ b/src/support/AliasFor.ts
@@ -1,16 +1,16 @@
-import { defaultMetadataStorage } from './storage';
+import { Entity } from '../Entity';
 import { EntityBuilder } from '../EntityBuilder';
 import { StringHelper } from './StringHelper';
 import { TypeMetadata } from './metadata/TypeMetadata';
-import { Entity } from '../Entity';
+import { defaultMetadataStorage } from './storage';
 
-export function Type(type?: Function, jsonKey?: string) {
-    return function (target: Entity, key: string) {
+export function AliasFor(key?: string) {
+    return function (target: Entity, jsonKey: string) {
         jsonKey = jsonKey ? jsonKey : (
             EntityBuilder.enableCamelConversion ? StringHelper.toSnake(key) : key
         );
 
-        const metadata = new TypeMetadata(target.constructor, key, jsonKey, type);
+        const metadata = new TypeMetadata(target.constructor, key, jsonKey, (value: any) => value);
         defaultMetadataStorage.addTypeMetadata(metadata);
     };
 }

--- a/src/support/Default.ts
+++ b/src/support/Default.ts
@@ -2,8 +2,6 @@ import 'reflect-metadata';
 import {defaultMetadataStorage} from "./storage";
 import {DefaultValueCallbackMetadata} from "./metadata/MetadataStorage";
 
-export type TypeOf<T> = { new(): T }
-
 export function Default<T>(callback: () => T, condition: (value: T) => boolean = (value) => value === null): (target: Object, propertyKey: string) => void {
     return function<T>(target: Function, propertyKey: string) {
         defaultMetadataStorage.addDefaultCallback(new DefaultValueCallbackMetadata(target.constructor, propertyKey, callback, condition))


### PR DESCRIPTION
This MR introduces proper definitions to return type of `toJson` and the first argument's type of `fromJson`.

Due to technical inabilities of Typescript, it is not yet possible to support aliasing via `@Type` decorator. ([Read here](https://github.com/Microsoft/TypeScript/issues/4881)) That's why I introduced a new decorator called `@AliasFor` which works backwards to `@Type`'s aliasing.

```typescript
// Current aliasing definition with @Type

class UserWithAliasedPrimitive extends User {
    @Type(String, 'second_name')
    public middleName: string;
}
```

```typescript
// Proposed aliasing definition with @AliasFor

class UserWithAliasedPrimitive extends User {
    @AliasFor('middleName')
    public secondName: string;
    public middleName: string;
}
```

This way all the possible property names are defined on the class, so Typescript can pick them up and use them to provide types for `toJson` and `fromJson`.