### PR TITLE
Some Improvements

### DIFF
--- a/spec/EntityBuilder.spec.ts
+++ b/spec/EntityBuilder.spec.ts
@@ -1,5 +1,5 @@
 import { EntityBuilder } from '../src/EntityBuilder';
-import { Entity } from '../src/Entity';
+import { Entity, PartialPropsJson } from '../src/Entity';
 import { Type } from '../src/support/Type';
 import { JsonExclude } from '../src/support/JsonExclude';
 
@@ -138,12 +138,17 @@ describe('EntityBuilder', () => {
     });
 
     it('interprets an annotated primitive as an alias', () => {
+        /*
+         * Type casting at the end is because EntityBuilder would not accept explicit aliased keys,
+         * but a real application will likely pass data directly from an API response, so this
+         * casting is not something consumer codebases will need to do most of the time.
+         */
         const user = EntityBuilder.buildOne(UserWithAliasedPrimitive, {
             name: 'Decahedron Technologies Ltd',
             email: 'hello@decahedron.io',
             days_available: ['Monday', 'Wednesday', 'Friday'],
             second_name: 'A Middle Name',
-        });
+        } as PartialPropsJson<UserWithAliasedPrimitive>);
 
         expect(user.middleName).toEqual('A Middle Name');
     });

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -1,6 +1,6 @@
 import { defaultMetadataStorage } from './support/storage';
-import { TypeMetadata } from './support/metadata/TypeMetadata';
-import { StringHelper } from './support/StringHelper';
+import { EntityBuilder } from './EntityBuilder';
+import { toJson } from './support/toJson';
 
 /**
  * This type converts given string's camelCase parts to snake_case.
@@ -98,55 +98,6 @@ export class Entity {
      * Convert an Entity to JSON, either in object or string format.
      */
     toJson(toSnake: boolean = true, asString: boolean = false): Props<this> | PropsJson<this> | string {
-        const data: any = {};
-
-        for (let key in this) {
-            if (!this.hasOwnProperty(key)) {
-                continue;
-            }
-
-            // exclude any properties with `@JsonExclude()`
-            if (defaultMetadataStorage.isPropertyExcluded(this.constructor, key)) {
-                continue;
-            }
-
-            let outputKey = toSnake ? StringHelper.toSnake(key) : key;
-
-            const value: any = this[key];
-
-            if (value instanceof Entity) {
-                data[outputKey] = value.toJson(toSnake, asString) as Props<typeof value>;
-
-                continue;
-            }
-
-            const metadata: TypeMetadata = defaultMetadataStorage.findTypeMetadata(this.constructor, key);
-
-            if (Array.isArray(value) && value.length > 0 && value[0] instanceof Object) {
-                if (value[0] instanceof Entity) {
-                    data[outputKey] = value.map((entity: Entity) => entity.toJson(toSnake, asString));
-                }
-
-                if (metadata && metadata.type === Object) {
-                    data[outputKey] = value;
-                }
-
-                continue;
-            }
-
-            // If the key has been manually annotated as an object,
-            // we will simply output the object itself.
-            if (value !== null && typeof value === 'object' && !(Array.isArray(value))) {
-                if (metadata && metadata.type === Object) {
-                    data[outputKey] = value;
-                }
-
-                continue;
-            }
-
-            data[outputKey] = value;
-        }
-
-        return asString ? JSON.stringify(data) : data;
+        return toJson<this>.call(this, toSnake, asString);
     }
 }

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -62,10 +62,8 @@ export type PartialPropsJson<T extends Entity> = Partial<{
 }>
 
 export class Entity {
-    [key: string]: any;
-
     hasProp(key: string): boolean {
-        if (Object.prototype.hasOwnProperty.call(this.constructor, key) || Object.prototype.hasOwnProperty.call(this, key)) {
+        if (Object.prototype.hasOwnProperty.call(this, key)) {
             return true;
         }
 
@@ -77,7 +75,7 @@ export class Entity {
             return;
         }
 
-        return this[key];
+        return (this as any)[key];
     }
 
     setProp(key: string, value: any) {
@@ -85,7 +83,7 @@ export class Entity {
             return;
         }
 
-        this[key] = value;
+        (this as any)[key] = value;
     }
 
     toJson(toSnake?: true, asString?: false): PropsJson<this>;

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -100,4 +100,9 @@ export class Entity {
     toJson(toSnake: boolean = true, asString: boolean = false): Props<this> | PropsJson<this> | string {
         return toJson<this>.call(this, toSnake, asString);
     }
+
+    fromJson(data: PartialPropsJson<this>): this {
+        EntityBuilder.fill(this, data);
+        return this;
+    }
 }

--- a/src/EntityBuilder.ts
+++ b/src/EntityBuilder.ts
@@ -11,8 +11,7 @@ export class EntityBuilder {
         sourceData: PartialPropsJson<T>,
     ): T {
         const entity = new (buildClass)();
-        EntityBuilder.fill<T>(entity, sourceData);
-        return entity;
+        return entity.fromJson(sourceData);
     }
 
     public static buildMany<T extends Entity>(
@@ -24,7 +23,7 @@ export class EntityBuilder {
         );
     }
 
-    private static fill<T extends Entity>(entity: T, data: PartialPropsJson<T>): T {
+    public static fill<T extends Entity>(entity: T, data: PartialPropsJson<T>): T {
         for (let key in data) {
             EntityBuilder.fillProperty<T>(entity, key, data[key]);
         }

--- a/src/support/toJson.ts
+++ b/src/support/toJson.ts
@@ -1,0 +1,57 @@
+import { defaultMetadataStorage } from './storage';
+import { StringHelper } from './StringHelper';
+import { TypeMetadata } from './metadata/TypeMetadata';
+import { Entity, Props, PropsJson } from '../Entity';
+
+export function toJson<T extends Entity>(this: T, toSnake: boolean = true, asString: boolean = false): Props<T> | PropsJson<T> | string {
+    const data: any = {};
+
+    for (let key in this) {
+        if (!this.hasOwnProperty(key)) {
+            continue;
+        }
+
+        // exclude any properties with `@JsonExclude()`
+        if (defaultMetadataStorage.isPropertyExcluded(this.constructor, key)) {
+            continue;
+        }
+
+        let outputKey = toSnake ? StringHelper.toSnake(key) : key;
+
+        const value: any = this[key];
+
+        if (value instanceof Entity) {
+            data[outputKey] = value.toJson(toSnake, asString) as Props<typeof value>;
+
+            continue;
+        }
+
+        const metadata: TypeMetadata = defaultMetadataStorage.findTypeMetadata(this.constructor, key);
+
+        if (Array.isArray(value) && value.length > 0 && value[0] instanceof Object) {
+            if (value[0] instanceof Entity) {
+                data[outputKey] = value.map((entity: Entity) => entity.toJson(toSnake, asString));
+            }
+
+            if (metadata && metadata.type === Object) {
+                data[outputKey] = value;
+            }
+
+            continue;
+        }
+
+        // If the key has been manually annotated as an object,
+        // we will simply output the object itself.
+        if (value !== null && typeof value === 'object' && !(Array.isArray(value))) {
+            if (metadata && metadata.type === Object) {
+                data[outputKey] = value;
+            }
+
+            continue;
+        }
+
+        data[outputKey] = value;
+    }
+
+    return asString ? JSON.stringify(data) : data;
+}


### PR DESCRIPTION
- I should have never deleted `fromJson` from entity class. It's very helpful to extend that functionality specialized to individual entities.
- Moved `toJson` out of entity file to make it look as lean as possible.
- Removed `Object.prototype.hasOwnProperty.call(this.constructor, key)` from `Entity.hasProp` method, because it should never check for static property existence.
- Some trivial changes to clean up codebase without changing anything.

Since 4.0.0 hasn't been published to NPM yet, I don't think we need to bump the version for this one.